### PR TITLE
Better huenest responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <suripu.version>0.8.5656</suripu.version>
-        <gaibu.version>0.1.43</gaibu.version>
+        <gaibu.version>0.1.44</gaibu.version>
         <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
         <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <suripu.version>0.8.5656</suripu.version>
-        <gaibu.version>0.1.41</gaibu.version>
+        <gaibu.version>0.1.43</gaibu.version>
         <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
         <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
     </properties>

--- a/supichi-core/src/main/java/is/hello/speech/core/handlers/HueHandler.java
+++ b/supichi-core/src/main/java/is/hello/speech/core/handlers/HueHandler.java
@@ -48,6 +48,7 @@ import is.hello.speech.core.models.HandlerResult;
 import is.hello.speech.core.models.HandlerType;
 import is.hello.speech.core.models.SpeechCommand;
 import is.hello.speech.core.models.VoiceRequest;
+import is.hello.speech.core.response.SupichiResponseType;
 
 
 /**
@@ -132,7 +133,7 @@ public class HueHandler extends BaseHandler {
             response.put("error", "no-application");
             response.put("result", Outcome.FAIL.getValue());
             hueResult = GenericResult.failWithResponse("expansion not found", SET_LIGHT_ERROR_APPLICATION);
-            return new HandlerResult(HandlerType.HUE, HandlerResult.EMPTY_COMMAND, response, Optional.of(hueResult));
+            return new HandlerResult(HandlerType.HUE, HandlerResult.EMPTY_COMMAND, updateResponse(response, hueResult), Optional.of(hueResult));
         }
 
         final Expansion expansion = expansionOptional.get();
@@ -146,7 +147,7 @@ public class HueHandler extends BaseHandler {
             response.put("error", "no-command");
             response.put("result", Outcome.FAIL.getValue());
             hueResult = GenericResult.failWithResponse("command not found", SET_LIGHT_ERROR_RESPONSE);
-            return new HandlerResult(HandlerType.HUE, HandlerResult.EMPTY_COMMAND, response, Optional.of(hueResult));
+            return new HandlerResult(HandlerType.HUE, HandlerResult.EMPTY_COMMAND, updateResponse(response, hueResult), Optional.of(hueResult));
         }
 
         final SpeechCommand command = optionalCommand.get();
@@ -157,8 +158,8 @@ public class HueHandler extends BaseHandler {
             LOGGER.error("error=token-not-found sense_id={}", senseId);
             response.put("error", "token-not-found");
             response.put("result", Outcome.FAIL.getValue());
-            hueResult = GenericResult.failWithResponse("token not found", SET_LIGHT_ERROR_AUTH);
-            return new HandlerResult(HandlerType.HUE, command.getValue(), response, Optional.of(hueResult));
+            hueResult = GenericResult.failWithResponse("token-not-found", SET_LIGHT_ERROR_AUTH);
+            return new HandlerResult(HandlerType.HUE, command.getValue(), updateResponse(response, hueResult), Optional.of(hueResult));
         }
 
         ExternalToken externalToken = externalTokenOptional.get();
@@ -173,7 +174,7 @@ public class HueHandler extends BaseHandler {
                 response.put("error", "token-refresh-failed");
                 response.put("result", Outcome.FAIL.getValue());
                 hueResult = GenericResult.failWithResponse("token refresh failed", SET_LIGHT_ERROR_AUTH);
-                return new HandlerResult(HandlerType.HUE, command.getValue(), response, Optional.of(hueResult));
+                return new HandlerResult(HandlerType.HUE, command.getValue(), updateResponse(response, hueResult), Optional.of(hueResult));
             }
 
             externalToken = refreshedTokenOptional.get();
@@ -189,7 +190,7 @@ public class HueHandler extends BaseHandler {
             response.put("error", "token-decryption-failure");
             response.put("result", Outcome.FAIL.getValue());
             hueResult = GenericResult.failWithResponse("token decrypt failed", SET_LIGHT_ERROR_AUTH);
-            return new HandlerResult(HandlerType.HUE, command.getValue(), response, Optional.of(hueResult));
+            return new HandlerResult(HandlerType.HUE, command.getValue(), updateResponse(response, hueResult), Optional.of(hueResult));
         }
 
         final String decryptedToken = decryptedTokenOptional.get();
@@ -200,7 +201,7 @@ public class HueHandler extends BaseHandler {
             response.put("error", "no-ext-app-data");
             response.put("result", Outcome.FAIL.getValue());
             hueResult = GenericResult.failWithResponse("no expansion data", SET_LIGHT_ERROR_CONFIG);
-            return new HandlerResult(HandlerType.HUE, command.getValue(), response, Optional.of(hueResult));
+            return new HandlerResult(HandlerType.HUE, command.getValue(), updateResponse(response, hueResult), Optional.of(hueResult));
         }
 
         final ExpansionData extData = extAppDataOptional.get();
@@ -209,7 +210,7 @@ public class HueHandler extends BaseHandler {
             response.put("error", "no-ext-app-data");
             response.put("result", Outcome.FAIL.getValue());
             hueResult = GenericResult.failWithResponse("no expansion data", SET_LIGHT_ERROR_CONFIG);
-            return new HandlerResult(HandlerType.HUE, command.getValue(), response, Optional.of(hueResult));
+            return new HandlerResult(HandlerType.HUE, command.getValue(), updateResponse(response, hueResult), Optional.of(hueResult));
         }
 
         HueLight light;
@@ -222,7 +223,7 @@ public class HueHandler extends BaseHandler {
             response.put("error", "bad-app-data");
             response.put("result", Outcome.FAIL.getValue());
             hueResult = GenericResult.failWithResponse("bad expansion data", SET_LIGHT_ERROR_CONFIG);
-            return new HandlerResult(HandlerType.HUE, command.getValue(), response, Optional.of(hueResult));
+            return new HandlerResult(HandlerType.HUE, command.getValue(), updateResponse(response, hueResult), Optional.of(hueResult));
         }
 
         if (command.equals(SpeechCommand.LIGHT_TOGGLE)) {
@@ -238,7 +239,7 @@ public class HueHandler extends BaseHandler {
                     GenericResult.ok(SET_LIGHT_OK_RESPONSE);
                     response.put("result", Outcome.OK.getValue());
                     hueResult = GenericResult.ok(SET_LIGHT_OK_RESPONSE);
-                    return new HandlerResult(HandlerType.HUE, command.getValue(), response, Optional.of(hueResult));
+                    return new HandlerResult(HandlerType.HUE, command.getValue(), updateResponse(response, hueResult), Optional.of(hueResult));
                 }
             }
         }
@@ -261,7 +262,7 @@ public class HueHandler extends BaseHandler {
                     if(isSuccessful) {
                         response.put("result", Outcome.OK.getValue());
                         hueResult = GenericResult.ok(SET_LIGHT_OK_RESPONSE);
-                        return new HandlerResult(HandlerType.HUE, command.getValue(), response, Optional.of(hueResult));
+                        return new HandlerResult(HandlerType.HUE, command.getValue(), updateResponse(response, hueResult), Optional.of(hueResult));
                     }
                 }
             }
@@ -283,7 +284,7 @@ public class HueHandler extends BaseHandler {
                     if(isSuccessful) {
                         response.put("result", Outcome.OK.getValue());
                         hueResult = GenericResult.ok(SET_LIGHT_OK_RESPONSE);
-                        return new HandlerResult(HandlerType.HUE, command.getValue(), response, Optional.of(hueResult));
+                        return new HandlerResult(HandlerType.HUE, command.getValue(), updateResponse(response, hueResult), Optional.of(hueResult));
                     }
                 }
             }
@@ -291,7 +292,7 @@ public class HueHandler extends BaseHandler {
 
         response.put("result", Outcome.FAIL.getValue());
         hueResult = GenericResult.failWithResponse("unknown command", SET_LIGHT_ERROR_RESPONSE);
-        return new HandlerResult(HandlerType.HUE, command.getValue(), response, Optional.of(hueResult));
+        return new HandlerResult(HandlerType.HUE, command.getValue(), updateResponse(response, hueResult), Optional.of(hueResult));
     }
     @Override
     public Integer matchAnnotations(final AnnotatedTranscript annotatedTranscript) {
@@ -385,5 +386,23 @@ public class HueHandler extends BaseHandler {
             LOGGER.error("error=token-not-saved");
             return Optional.absent();
         }
+    }
+
+    public Map<String, String> updateResponse(final Map<String, String> response, final GenericResult result) {
+        response.put("result", result.outcome.getValue());
+        if (result.errorText.isPresent()) {
+            response.put("error", result.errorText.get());
+            if (result.responseText.isPresent()) {
+                response.put("text", result.responseText());
+            }
+        } else {
+            response.put("text", result.responseText());
+        }
+        return response;
+    }
+
+    @Override
+    public SupichiResponseType responseType() {
+        return SupichiResponseType.WATSON;
     }
 }

--- a/supichi-core/src/main/java/is/hello/speech/core/handlers/HueHandler.java
+++ b/supichi-core/src/main/java/is/hello/speech/core/handlers/HueHandler.java
@@ -70,11 +70,11 @@ public class HueHandler extends BaseHandler {
     public static final Integer BRIGHTNESS_DECREMENT = -BRIGHTNESS_INCREMENT;
     public static final Integer COLOR_TEMPERATURE_INCREMENT = 100;
     public static final Integer COLOR_TEMPERATURE_DECREMENT = -COLOR_TEMPERATURE_INCREMENT;
-    public static final String SET_LIGHT_OK_RESPONSE = "Okay, it is done.";
-    public static final String SET_LIGHT_ERROR_RESPONSE = "Sorry, we're unable to adjust your lights. Please try again later";
-    public static final String SET_LIGHT_ERROR_AUTH = "Sorry, we're unable to adjust your lights. Please configure Hue in the Sense app and try again.";
-    public static final String SET_LIGHT_ERROR_CONFIG = "Sorry, we're unable to adjust your lights. Please select a Hue light group in the Sense app and try again.";
-    public static final String SET_LIGHT_ERROR_APPLICATION = "Sorry, we're unable to adjust your lights. This expansion is currently unavailable.";
+    public static final String SET_LIGHT_OK_RESPONSE = "Okay, done";
+    public static final String SET_LIGHT_ERROR_RESPONSE = "Sorry, your lights could not be reached";
+    public static final String SET_LIGHT_ERROR_AUTH = "Please connect your lights on the Sense app under Expansions";
+    public static final String SET_LIGHT_ERROR_CONFIG = "Please connect your lights on the Sense app under Expansions";
+    public static final String SET_LIGHT_ERROR_APPLICATION = "Sorry, your lights could not be reached";
 
     public HueHandler(final String hueAppName,
                       final SpeechCommandDAO speechCommandDAO,

--- a/supichi-core/src/main/java/is/hello/speech/core/handlers/HueHandler.java
+++ b/supichi-core/src/main/java/is/hello/speech/core/handlers/HueHandler.java
@@ -154,7 +154,7 @@ public class HueHandler extends BaseHandler {
 
         final Optional<ExternalToken> externalTokenOptional = externalTokenStore.getTokenByDeviceId(senseId, expansion.id);
         if(!externalTokenOptional.isPresent()) {
-            LOGGER.error("error=token-not-found device_id={}", senseId);
+            LOGGER.error("error=token-not-found sense_id={}", senseId);
             response.put("error", "token-not-found");
             response.put("result", Outcome.FAIL.getValue());
             hueResult = GenericResult.failWithResponse("token not found", SET_LIGHT_ERROR_AUTH);
@@ -165,11 +165,11 @@ public class HueHandler extends BaseHandler {
 
         //check for expired token and attempt refresh
         if(externalToken.hasExpired(DateTime.now(DateTimeZone.UTC))) {
-            LOGGER.error("error=token-expired device_id={}", senseId);
+            LOGGER.error("error=token-expired sense_id={}", senseId);
 
             final Optional<ExternalToken> refreshedTokenOptional = refreshToken(senseId, expansion, externalToken);
             if(!refreshedTokenOptional.isPresent()){
-                LOGGER.error("error=token-refresh-failed device_id={}", senseId);
+                LOGGER.error("error=token-refresh-failed sense_id={}", senseId);
                 response.put("error", "token-refresh-failed");
                 response.put("result", Outcome.FAIL.getValue());
                 hueResult = GenericResult.failWithResponse("token refresh failed", SET_LIGHT_ERROR_AUTH);
@@ -185,7 +185,7 @@ public class HueHandler extends BaseHandler {
 
 
         if(!decryptedTokenOptional.isPresent()) {
-            LOGGER.error("error=token-decryption-failure device_id={}", senseId);
+            LOGGER.error("error=token-decryption-failure sense_id={}", senseId);
             response.put("error", "token-decryption-failure");
             response.put("result", Outcome.FAIL.getValue());
             hueResult = GenericResult.failWithResponse("token decrypt failed", SET_LIGHT_ERROR_AUTH);
@@ -218,7 +218,7 @@ public class HueHandler extends BaseHandler {
             light = HueLight.create(hueAppName, expansion.apiURI, decryptedToken, hueData.bridgeId, hueData.whitelistId, hueData.groupId);
 
         } catch (IOException io) {
-            LOGGER.error("error=bad-app-data device_id={}", senseId);
+            LOGGER.error("error=bad-app-data sense_id={}", senseId);
             response.put("error", "bad-app-data");
             response.put("result", Outcome.FAIL.getValue());
             hueResult = GenericResult.failWithResponse("bad expansion data", SET_LIGHT_ERROR_CONFIG);
@@ -305,7 +305,7 @@ public class HueHandler extends BaseHandler {
 
         final Optional<String> decryptedRefreshTokenOptional = tokenKMSVault.decrypt(externalToken.refreshToken, encryptionContext);
         if(!decryptedRefreshTokenOptional.isPresent()) {
-            LOGGER.error("error=refresh-decrypt-failed device_id={}", deviceId);
+            LOGGER.error("error=refresh-decrypt-failed sense_id={}", deviceId);
             return Optional.absent();
         }
         final String decryptedRefreshToken = decryptedRefreshTokenOptional.get();

--- a/supichi-core/src/main/java/is/hello/speech/core/handlers/NestHandler.java
+++ b/supichi-core/src/main/java/is/hello/speech/core/handlers/NestHandler.java
@@ -30,6 +30,7 @@ import is.hello.speech.core.models.HandlerResult;
 import is.hello.speech.core.models.HandlerType;
 import is.hello.speech.core.models.SpeechCommand;
 import is.hello.speech.core.models.VoiceRequest;
+import is.hello.speech.core.response.SupichiResponseType;
 
 
 public class NestHandler extends BaseHandler {
@@ -120,7 +121,7 @@ public class NestHandler extends BaseHandler {
             response.put("error", "no-application");
             response.put("result", Outcome.FAIL.getValue());
             nestResult = GenericResult.failWithResponse("expansion not found", SET_TEMP_ERROR_APPLICATION);
-            return new HandlerResult(HandlerType.NEST, HandlerResult.EMPTY_COMMAND, response, Optional.of(nestResult));
+            return new HandlerResult(HandlerType.NEST, HandlerResult.EMPTY_COMMAND, updateResponse(response, nestResult), Optional.of(nestResult));
         }
 
         final Expansion expansion = expansionOptional.get();
@@ -132,7 +133,7 @@ public class NestHandler extends BaseHandler {
             response.put("error", "no-command");
             response.put("result", Outcome.FAIL.getValue());
             nestResult = GenericResult.failWithResponse("command not found", SET_TEMP_ERROR_RESPONSE);
-            return new HandlerResult(HandlerType.NEST, HandlerResult.EMPTY_COMMAND, response, Optional.of(nestResult));
+            return new HandlerResult(HandlerType.NEST, HandlerResult.EMPTY_COMMAND, updateResponse(response, nestResult), Optional.of(nestResult));
         }
 
         final SpeechCommand command = optionalCommand.get();
@@ -142,7 +143,7 @@ public class NestHandler extends BaseHandler {
             response.put("error", "null-sense-id");
             response.put("result", Outcome.FAIL.getValue());
             nestResult = GenericResult.failWithResponse("sense_id not found", SET_TEMP_ERROR_RESPONSE);
-            return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+            return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
         }
 
         final Optional<ExternalToken> externalTokenOptional = externalTokenStore.getTokenByDeviceId(senseId, expansion.id);
@@ -150,8 +151,8 @@ public class NestHandler extends BaseHandler {
             LOGGER.error("error=token-not-found sense_id={}", senseId);
             response.put("error", "token-not-found");
             response.put("result", Outcome.FAIL.getValue());
-            nestResult = GenericResult.failWithResponse("command not found", SET_TEMP_ERROR_AUTH);
-            return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+            nestResult = GenericResult.failWithResponse("token-not-found", SET_TEMP_ERROR_AUTH);
+            return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
         }
 
         final ExternalToken externalToken = externalTokenOptional.get();
@@ -165,7 +166,7 @@ public class NestHandler extends BaseHandler {
             response.put("error", "token-decryption-failure");
             response.put("result", Outcome.FAIL.getValue());
             nestResult = GenericResult.failWithResponse("token decrypt failed", SET_TEMP_ERROR_AUTH);
-            return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+            return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
         }
 
         final String decryptedToken = decryptedTokenOptional.get();
@@ -176,7 +177,7 @@ public class NestHandler extends BaseHandler {
             response.put("error", "no-ext-app-data");
             response.put("result", Outcome.FAIL.getValue());
             nestResult = GenericResult.failWithResponse("no expansion data", SET_TEMP_ERROR_CONFIG);
-            return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+            return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
         }
 
         final ExpansionData extData = extAppDataOptional.get();
@@ -186,7 +187,7 @@ public class NestHandler extends BaseHandler {
             response.put("error", "no-ext-app-data");
             response.put("result", Outcome.FAIL.getValue());
             nestResult = GenericResult.failWithResponse("no expansion data", SET_TEMP_ERROR_CONFIG);
-            return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+            return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
         }
 
         NestThermostat nest;
@@ -199,7 +200,7 @@ public class NestHandler extends BaseHandler {
             response.put("error", "bad-app-data");
             response.put("result", Outcome.FAIL.getValue());
             nestResult = GenericResult.failWithResponse("bad expansion data", SET_TEMP_ERROR_CONFIG);
-            return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+            return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
         }
 
         if (command.equals(SpeechCommand.THERMOSTAT_SET)) {
@@ -219,13 +220,13 @@ public class NestHandler extends BaseHandler {
                     response.put("temp_set", temperatureSum.toString());
                     response.put("result", Outcome.OK.getValue());
                     nestResult = GenericResult.ok(SET_TEMP_OK_RESPONSE);
-                    return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+                    return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
                 }
 
                 response.put("temp_set", temperatureSum.toString());
                 response.put("result", Outcome.FAIL.getValue());
                 nestResult = GenericResult.failWithResponse("command failed", SET_TEMP_ERROR_RESPONSE);
-                return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+                return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
             }
 
             final Pattern numeric = Pattern.compile(TEMP_SET_PATTERN_NUMERIC);
@@ -236,7 +237,7 @@ public class NestHandler extends BaseHandler {
                 response.put("temp_set", temperatureSum.toString());
                 response.put("result", Outcome.OK.getValue());
                 nestResult = GenericResult.ok(SET_TEMP_OK_RESPONSE);
-                return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+                return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
             }
         }
 
@@ -252,14 +253,14 @@ public class NestHandler extends BaseHandler {
                 response.put("error", "no-pattern-match");
                 response.put("result", Outcome.FAIL.getValue());
                 nestResult = GenericResult.failWithResponse("no pattern match", SET_TEMP_ERROR_RESPONSE);
-                return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+                return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
             }
         }
 
         LOGGER.warn("error=no-pattern-match app_name=nest sense_id={}", senseId);
         response.put("result", Outcome.FAIL.getValue());
         nestResult = GenericResult.failWithResponse("no command found", SET_TEMP_ERROR_RESPONSE);
-        return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));
+        return new HandlerResult(HandlerType.NEST, command.getValue(), updateResponse(response, nestResult), Optional.of(nestResult));
 
     }
 
@@ -269,4 +270,21 @@ public class NestHandler extends BaseHandler {
         return NO_ANNOTATION_SCORE;
     }
 
+    @Override
+    public SupichiResponseType responseType() {
+        return SupichiResponseType.WATSON;
+    }
+
+    public Map<String, String> updateResponse(final Map<String, String> response, final GenericResult result) {
+        response.put("result", result.outcome.getValue());
+        if (result.errorText.isPresent()) {
+            response.put("error", result.errorText.get());
+            if (result.responseText.isPresent()) {
+                response.put("text", result.responseText());
+            }
+        } else {
+            response.put("text", result.responseText());
+        }
+        return response;
+    }
 }

--- a/supichi-core/src/main/java/is/hello/speech/core/handlers/NestHandler.java
+++ b/supichi-core/src/main/java/is/hello/speech/core/handlers/NestHandler.java
@@ -147,7 +147,7 @@ public class NestHandler extends BaseHandler {
 
         final Optional<ExternalToken> externalTokenOptional = externalTokenStore.getTokenByDeviceId(senseId, expansion.id);
         if(!externalTokenOptional.isPresent()) {
-            LOGGER.error("error=token-not-found device_id={}", senseId);
+            LOGGER.error("error=token-not-found sense_id={}", senseId);
             response.put("error", "token-not-found");
             response.put("result", Outcome.FAIL.getValue());
             nestResult = GenericResult.failWithResponse("command not found", SET_TEMP_ERROR_AUTH);
@@ -161,7 +161,7 @@ public class NestHandler extends BaseHandler {
         final Optional<String> decryptedTokenOptional = tokenKMSVault.decrypt(externalToken.accessToken, encryptionContext);
 
         if(!decryptedTokenOptional.isPresent()) {
-            LOGGER.error("error=token-decryption-failure device_id={}", senseId);
+            LOGGER.error("error=token-decryption-failure sense_id={}", senseId);
             response.put("error", "token-decryption-failure");
             response.put("result", Outcome.FAIL.getValue());
             nestResult = GenericResult.failWithResponse("token decrypt failed", SET_TEMP_ERROR_AUTH);
@@ -195,7 +195,7 @@ public class NestHandler extends BaseHandler {
             nest = NestThermostat.create(expansion.apiURI, decryptedToken, nestData.thermostatId);
 
         } catch (IOException io) {
-            LOGGER.warn("error=bad-app-data app_name=nest device_id={}", senseId);
+            LOGGER.warn("error=bad-app-data app_name=nest sense_id={}", senseId);
             response.put("error", "bad-app-data");
             response.put("result", Outcome.FAIL.getValue());
             nestResult = GenericResult.failWithResponse("bad expansion data", SET_TEMP_ERROR_CONFIG);
@@ -248,7 +248,7 @@ public class NestHandler extends BaseHandler {
                 isOn = m.group(1).startsWith("on");
 
             } else {
-                LOGGER.warn("error=no-pattern-match app_name=nest device_id={}", senseId);
+                LOGGER.warn("error=no-pattern-match app_name=nest sense_id={}", senseId);
                 response.put("error", "no-pattern-match");
                 response.put("result", Outcome.FAIL.getValue());
                 nestResult = GenericResult.failWithResponse("no pattern match", SET_TEMP_ERROR_RESPONSE);
@@ -256,7 +256,7 @@ public class NestHandler extends BaseHandler {
             }
         }
 
-        LOGGER.warn("error=no-pattern-match app_name=nest device_id={}", senseId);
+        LOGGER.warn("error=no-pattern-match app_name=nest sense_id={}", senseId);
         response.put("result", Outcome.FAIL.getValue());
         nestResult = GenericResult.failWithResponse("no command found", SET_TEMP_ERROR_RESPONSE);
         return new HandlerResult(HandlerType.NEST, command.getValue(), response, Optional.of(nestResult));

--- a/supichi-core/src/main/java/is/hello/speech/core/handlers/NestHandler.java
+++ b/supichi-core/src/main/java/is/hello/speech/core/handlers/NestHandler.java
@@ -39,11 +39,11 @@ public class NestHandler extends BaseHandler {
     private static final String TEMP_SET_PATTERN_NUMERIC = "(?i)^.*(?:nest|thermostat|temp)?\\sto\\s(\\d+)\\sdegrees";
     private static final String TOGGLE_ACTIVE_PATTERN = "(?i)^.*turn.*(?:nest|thermostat)?\\s(on|off).*(?:nest|thermostat)?";
 
-    public static final String SET_TEMP_OK_RESPONSE = "Okay, it is done.";
-    public static final String SET_TEMP_ERROR_RESPONSE = "Sorry, we're unable to adjust your thermostat. Please try again later";
-    public static final String SET_TEMP_ERROR_AUTH = "Sorry, we're unable to adjust your thermostat. Please configure Nest in the Sense app and try again.";
-    public static final String SET_TEMP_ERROR_CONFIG = "Sorry, we're unable to adjust your thermostat. Please select a Nest thermostat in the Sense app and try again.";
-    public static final String SET_TEMP_ERROR_APPLICATION = "Sorry, we're unable to adjust your thermostat. This expansion is currently unavailable.";
+    public static final String SET_TEMP_OK_RESPONSE = "Okay, done";
+    public static final String SET_TEMP_ERROR_RESPONSE = "Sorry, your thermostat could not be reached";
+    public static final String SET_TEMP_ERROR_AUTH = "Please connect your thermostat on the Sense app under Expansions";
+    public static final String SET_TEMP_ERROR_CONFIG = "Please connect your thermostat on the Sense app under Expansions";
+    public static final String SET_TEMP_ERROR_APPLICATION = "Sorry, your thermostat could not be reached";
 
     private final SpeechCommandDAO speechCommandDAO;
     private final PersistentExternalTokenStore externalTokenStore;


### PR DESCRIPTION
- Using GenericResult()
- standardizing on `sense_id`

This still has token refresh in the handler. I am going to move that out into a better location (Gaibu) as I finish the Alarm Actions.
